### PR TITLE
Update 0.9.32

### DIFF
--- a/TurnBased/ChangeLog.txt
+++ b/TurnBased/ChangeLog.txt
@@ -1,4 +1,5 @@
 ﻿Version 0.9.32
+    Added the "Try To Avoid Overlapping When Moving Through Friends" option
     Fixed the "Fix x as y action" options are accidentally broken by the previous update
 
 Version 0.9.31
@@ -51,7 +52,7 @@ Version 0.9.24
 Version 0.9.23
     Added an option to fix the cost of action to start Bardic Performance
     Fixed sometimes a Charge ability would be interrupted due to an unexpected obstacle
-    Fixed if a unit used Charge ability on its turn, other units can move through or stack with the charged unit in the next one second (game time)
+    Fixed if a unit used Charge ability on its turn, other units can move through or overlap with the charged unit in the next one second
 
 Version 0.9.22
     Added the "Auto Select The Entire Party After Combat End" option

--- a/TurnBased/ChangeLog.txt
+++ b/TurnBased/ChangeLog.txt
@@ -1,6 +1,9 @@
-﻿Version 0.9.31
+﻿Version 0.9.32
+    Fixed the "Fix x as y action" options are accidentally broken by the previous update
+
+Version 0.9.31
 	Added the Unity Mod Manager support for checking the availability of updates
-	Fixed th "Auto Turn On AI ..." option "is accidentally binding to the "Auto Turn Off AI ..." option
+	Fixed the "Auto Turn On AI ..." option "is accidentally binding to the "Auto Turn Off AI ..." option
 	
 Version 0.9.30
     Added a temporary bugfix, which fix a vanilla bug that the ability circle won't show up if you first select it via hotkey

--- a/TurnBased/ChangeLog.txt
+++ b/TurnBased/ChangeLog.txt
@@ -108,7 +108,7 @@ Version 0.9.16
 Version 0.9.15
     Improved combat UI, better skin and offering more info
     Improved time accuracy
-    Implemented "Moving Through Friend﻿" as an option
+    Implemented "Moving Through Friend﻿s" as an option
     Changed some code logic, supposed to make it work more properly, but might cause new bugs
     Fixed the turn will be more than 6s if the time goes too fast
     Fixed the confusion effects sometimes does not work properly

--- a/TurnBased/ChangeLog.txt
+++ b/TurnBased/ChangeLog.txt
@@ -1,6 +1,7 @@
 ﻿Version 0.9.32
     Added the "Try To Avoid Overlapping When Moving Through Friends" option
     Fixed the "Fix x as y action" options are accidentally broken by the previous update
+	Fixed units won't leave combat when their in-game state changes (caused Call Forth Kanerah/Kalikke glitch)
 
 Version 0.9.31
 	Added the Unity Mod Manager support for checking the availability of updates

--- a/TurnBased/ChangeLog.txt
+++ b/TurnBased/ChangeLog.txt
@@ -1,5 +1,6 @@
 ﻿Version 0.9.32
     Added the "Try To Avoid Overlapping When Moving Through Friends" option
+	Changed the combat tracker won't be shown during a dialogue anymore
     Fixed the "Fix x as y action" options are accidentally broken by the previous update
 	Fixed units won't leave combat when their in-game state changes (caused Call Forth Kanerah/Kalikke glitch)
 

--- a/TurnBased/Controllers/BlueprintController.cs
+++ b/TurnBased/Controllers/BlueprintController.cs
@@ -18,7 +18,7 @@ namespace TurnBased.Controllers
         private bool? _backupChargeIsFullRoundAction;
         private bool[] _backupVitalStrikeIsFullRoundAction;
 
-        public LibraryScriptableObject LibraryObject = typeof(ResourcesLibrary).GetFieldValue<LibraryScriptableObject>("s_LibraryObject");
+        public LibraryScriptableObject LibraryObject => typeof(ResourcesLibrary).GetFieldValue<LibraryScriptableObject>("s_LibraryObject");
 
         public void Update()
         {

--- a/TurnBased/Core.cs
+++ b/TurnBased/Core.cs
@@ -17,7 +17,6 @@ namespace TurnBased
         ISceneHandler
     {
         internal Dictionary<AbilityExecutionProcess, TimeSpan> LastTickTimeOfAbilityExecutionProcess = new Dictionary<AbilityExecutionProcess, TimeSpan>();
-        internal UnitEntityData PathfindingUnit;
 
         public BlueprintController Blueprint { get; internal set; } = new BlueprintController();
 
@@ -57,7 +56,6 @@ namespace TurnBased
             HotkeyHelper.Bind(HOTKEY_FOR_TOGGLE_MODE, HandleToggleTurnBasedMode);
 
             Mod.Core.LastTickTimeOfAbilityExecutionProcess.Clear();
-            Mod.Core.PathfindingUnit = null;
         }
     }
 }

--- a/TurnBased/HarmonyPatches/CollisionDetection.cs
+++ b/TurnBased/HarmonyPatches/CollisionDetection.cs
@@ -1,7 +1,5 @@
 ﻿using Harmony12;
-using Kingmaker.EntitySystem.Entities;
 using Kingmaker.View;
-using Pathfinding;
 using TurnBased.Utility;
 using static TurnBased.Main;
 using static TurnBased.Utility.SettingsWrapper;
@@ -11,49 +9,17 @@ namespace TurnBased.HarmonyPatches
 {
     static class CollisionDetection
     {
-
         // moving through friend feature
-        [HarmonyPatch(typeof(UnitMovementAgent), "UpdateUnitAvoidance")]
-        static class UnitMovementAgent_UpdateUnitAvoidance_Patch
+        [HarmonyPatch(typeof(UnitMovementAgent), nameof(UnitMovementAgent.AvoidanceDisabled), MethodType.Getter)]
+        static class UnitMovementAgent_AvoidanceDisabled_Patch
         {
             [HarmonyPrefix]
-            static bool Prefix(UnitMovementAgent __instance, UnitEntityData unit)
+            static void Postfix(UnitMovementAgent __instance, ref bool __result)
             {
-                return !IsInCombat() || !(__instance.Unit?.EntityData).CanMoveThrough(unit);
-            }
-        }
-
-        // moving through friend feature
-        [HarmonyPatch(typeof(UnitMovementAgent), "OnPathComplete", typeof(Path))]
-        static class UnitMovementAgent_OnPathComplete_Patch
-        {
-            [HarmonyPrefix]
-            static void Prefix(UnitMovementAgent __instance)
-            {
-                if (IsInCombat())
+                if (IsInCombat() && !__result)
                 {
-                    Mod.Core.PathfindingUnit = __instance.Unit?.EntityData;
+                    __result = (Mod.Core.Combat.CurrentTurn?.Unit).CanMoveThrough(__instance.Unit?.EntityData);
                 }
-            }
-
-            [HarmonyPostfix]
-            static void Postfix()
-            {
-                if (IsInCombat())
-                {
-                    Mod.Core.PathfindingUnit = null;
-                }
-            }
-        }
-
-        // moving through friend feature
-        [HarmonyPatch(typeof(ObstaclePathfinder), "IntersectObstacle")]
-        static class ObstaclePathfinder_IntersectObstacle_Patch
-        {
-            [HarmonyPrefix]
-            static bool Prefix(UnitMovementAgent unit)
-            {
-                return !IsInCombat() || !Mod.Core.PathfindingUnit.CanMoveThrough(unit.Unit?.EntityData);
             }
         }
 

--- a/TurnBased/Menus/GameplayOptions.cs
+++ b/TurnBased/Menus/GameplayOptions.cs
@@ -74,7 +74,7 @@ namespace TurnBased.Menus
 
             MovingThroughFriends =
                 GUIHelper.ToggleButton(MovingThroughFriends,
-                "Moving Through Friend﻿s" +
+                "Moving Through Friends" +
                 " (Units can move through allies)".Color(RGBA.silver), _buttonStyle, GUILayout.ExpandWidth(false));
 
             MovingThroughNonEnemies =
@@ -89,6 +89,10 @@ namespace TurnBased.Menus
             MovingThroughOnlyAffectNonEnemies =
                 GUIHelper.ToggleButton(MovingThroughOnlyAffectNonEnemies,
                 "Moving Through ... Only Affect Non-Enemies", _buttonStyle, GUILayout.ExpandWidth(false));
+
+            AvoidOverlapping =
+                GUIHelper.ToggleButton(AvoidOverlapping,
+                "Try To Avoid Overlapping When Moving Through Friends", _buttonStyle, GUILayout.ExpandWidth(false));
 
             GUILayout.Space(10f);
 

--- a/TurnBased/Settings.cs
+++ b/TurnBased/Settings.cs
@@ -13,11 +13,12 @@ namespace TurnBased
         public bool toggleFlankingCountAllOpponentsWithinThreatenRange = true;
         public float distanceOfFiveFootStep = 1.5f;
 
-        public bool toggleMovingThroughFriends;
+        public bool toggleMovingThroughFriends = true;
         public bool toggleMovingThroughNonEnemies;
-        public bool toggleMovingThroughOnlyAffectPlayer = true;
+        public bool toggleMovingThroughOnlyAffectPlayer;
         public bool toggleMovingThroughOnlyAffectNonEnemies;
-        public float radiusOfCollision = 0.7f;
+        public bool toggleAvoidOverlapping = true;
+        public float radiusOfCollision = 0.9f;
 
         public bool toggleAutoTurnOffPlayerAI = true;
         public bool toggleAutoTurnOnPlayerAI = true;

--- a/TurnBased/Utility/SettingsWrapper.cs
+++ b/TurnBased/Utility/SettingsWrapper.cs
@@ -121,6 +121,11 @@ namespace TurnBased.Utility
             }
         }
 
+        public static bool AvoidOverlapping {
+            get => Mod.Settings.toggleAvoidOverlapping;
+            set => Mod.Settings.toggleAvoidOverlapping = value;
+        }
+
         public static float RadiusOfCollision {
             get => Mod.Settings.radiusOfCollision;
             set => Mod.Settings.radiusOfCollision = value;

--- a/TurnBased/Utility/StatusWrapper.cs
+++ b/TurnBased/Utility/StatusWrapper.cs
@@ -15,7 +15,7 @@ namespace TurnBased.Utility
         public static bool IsInCombat()
         {
             return Mod.Enabled && Mod.Core.Combat.CombatInitialized &&
-                Game.Instance.CurrentMode != GameModeType.Cutscene;
+                (Game.Instance.CurrentMode == GameModeType.Default || Game.Instance.CurrentMode == GameModeType.Pause);
         }
 
         public static bool IsPreparing()

--- a/TurnBased/Utility/UnitEntityDataExtensions.cs
+++ b/TurnBased/Utility/UnitEntityDataExtensions.cs
@@ -32,7 +32,7 @@ namespace TurnBased.Utility
 
         public static bool CanMoveThrough(this UnitEntityData unit, UnitEntityData target)
         {
-            return unit != null && target != null &&
+            return unit != null && target != null && unit != target &&
                 (!MovingThroughOnlyAffectPlayer || unit.IsPlayerFaction) &&
                 (!MovingThroughOnlyAffectNonEnemies || !unit.IsPlayersEnemy) &&
                 ((MovingThroughNonEnemies && !unit.IsEnemy(target)) || (MovingThroughFriends && unit.IsAlly(target))) &&

--- a/TurnBased/Utility/UnitEntityDataExtensions.cs
+++ b/TurnBased/Utility/UnitEntityDataExtensions.cs
@@ -35,7 +35,32 @@ namespace TurnBased.Utility
             return unit != null && target != null &&
                 (!MovingThroughOnlyAffectPlayer || unit.IsPlayerFaction) &&
                 (!MovingThroughOnlyAffectNonEnemies || !unit.IsPlayersEnemy) &&
-                ((MovingThroughNonEnemies && !unit.IsEnemy(target)) || (MovingThroughFriends && unit.IsAlly(target)));
+                ((MovingThroughNonEnemies && !unit.IsEnemy(target)) || (MovingThroughFriends && unit.IsAlly(target))) &&
+                (!AvoidOverlapping || !unit.JustOverlapping(target));
+        }
+
+        private static bool JustOverlapping(this UnitEntityData unit, UnitEntityData target)
+        {
+            Vector3? destination = unit.View.AgentASP.GetFieldValue<UnitMovementAgent, Vector3?>("m_Destination");
+
+            if (!destination.HasValue)
+                return false;
+
+            float minDistance = unit.View.AgentASP.Corpulence + target.View.AgentASP.Corpulence;
+
+            // the destination is not where the unit is intended to stop at, so we have to step back
+            destination = destination.Value + (unit.Position - destination.Value).normalized * unit.View.AgentASP.ApproachRadius;
+
+            // if the destination is going to overlap with target, forbid this behavior
+            if (target.DistanceTo(destination.Value) < minDistance)
+                return true;
+
+            // if the unit doesn't have enough movement to go through the target, forbid it from going through
+            if (unit.IsCurrentUnit())
+                return Mod.Core.Combat.CurrentTurn.GetRemainingMovementRange(true) < 
+                    Math.Min(unit.DistanceTo(target) + minDistance, unit.DistanceTo(destination.Value));
+
+            return false;
         }
 
         public static bool CanPerformAction(this UnitEntityData unit)


### PR DESCRIPTION
- Fix the "Fix x as y action" options. 
- Add the "Try To Avoid Overlapping" option. 
- Change the implementation of "Moving Through Friends﻿". 
- Fix units won't leave combat when their in-game state changes. 
- Make the combat tracker won't be shown during a dialogue anymore. 